### PR TITLE
Enable specifying time- and OD-dependent adaptive ratio

### DIFF
--- a/src/dta.cpp
+++ b/src/dta.cpp
@@ -333,6 +333,8 @@ MNM_Dta::build_from_files ()
   MNM_IO::read_origin_vehicle_label_ratio (m_file_folder, m_config,
                                            m_od_factory);
   MNM_IO::build_link_toll (m_file_folder, m_config, m_link_factory);
+  MNM_IO::build_link_td_attribute(m_file_folder, m_link_factory);
+  MNM_IO::build_td_adaptive_ratio(m_file_folder, m_config, m_od_factory);
   build_workzone ();
   set_statistics ();
   set_gridlock_recorder ();
@@ -506,6 +508,7 @@ MNM_Dta::pre_loading ()
       _node->prepare_loading ();
     }
   // printf("dsf\n");
+  // TODO: workzone not compatible with new graph(), but workzone can be realized using time-dependent link attribute
   // m_workzone -> init_workzone();
 
   // https://stackoverflow.com/questions/7443787/using-c-ifstream-extraction-operator-to-read-formatted-data-from-a-file

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -129,10 +129,22 @@ MNM_Node_Factory::get_node (TInt ID)
 MNM_Link_Factory::MNM_Link_Factory ()
 {
   m_link_map = std::unordered_map<TInt, MNM_Dlink *> ();
+  m_td_link_attribute_table = new std::unordered_map<
+    int, std::unordered_map<int, td_link_attribute_row *> *> ();
 }
 
 MNM_Link_Factory::~MNM_Link_Factory ()
 {
+  for (auto _it : *m_td_link_attribute_table)
+    {
+      for (auto _it_it : *(_it.second))
+        {
+          delete _it_it.second;
+        }
+      _it.second->clear ();
+    }
+  m_td_link_attribute_table->clear ();
+  
   for (auto _map_it = m_link_map.begin (); _map_it != m_link_map.end ();
        _map_it++)
     {

--- a/src/factory.h
+++ b/src/factory.h
@@ -41,6 +41,17 @@ public:
   std::unordered_map<TInt, MNM_Dnode *> m_node_map;
 };
 
+struct td_link_attribute_row
+{
+  std::string link_type;
+  float length;
+  float FFS;
+  float Cap;
+  float RHOJ;
+  int Lane;
+  float toll;
+};
+
 class MNM_Link_Factory
 {
 public:
@@ -57,6 +68,8 @@ public:
     return 0;
   };
   std::unordered_map<TInt, MNM_Dlink *> m_link_map;
+  std::unordered_map<int, std::unordered_map<int, td_link_attribute_row *> *>
+    *m_td_link_attribute_table;
 };
 
 class MNM_OD_Factory

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -676,7 +676,7 @@ int MNM_IO::build_td_adaptive_ratio (const std::string &file_folder,
   if (_ratio_file.is_open ())
     {
       // printf("Start build demand profile.\n");
-      TFlt *_ratio_vector = (TFlt *) malloc (sizeof (TFlt) * _max_interval);
+      double *_ratio_vector = new double[_max_interval]();
       std::getline (_ratio_file, _line);
       while (std::getline (_ratio_file, _line))
         {
@@ -699,11 +699,11 @@ int MNM_IO::build_td_adaptive_ratio (const std::string &file_folder,
             }
           else
             {
-              free (_ratio_vector);
+              delete[] _ratio_vector;
               throw std::runtime_error ("failed to build time-dependent adaptive ratio");
             }
         }
-      free (_ratio_vector);
+      delete[] _ratio_vector;
       _ratio_file.close ();
     }
   else {

--- a/src/io.h
+++ b/src/io.h
@@ -95,6 +95,16 @@ public:
     const std::string &interval_tracking_file_name
     = "MNM_input_interval_tracking");
 
+  static int build_link_td_attribute (const std::string &file_folder,
+                                    MNM_Link_Factory *link_factory,
+                                    const std::string &file_name
+                                    = "MNM_input_link_td_attribute");
+
+  static int build_td_adaptive_ratio (const std::string &file_folder,
+                                    MNM_ConfReader *conf_reader,
+                                    MNM_OD_Factory *od_factory,
+                                    const std::string &file_name = "MNM_input_od_td_adaptive_ratio");
+
   // private:
   static std::vector<std::string> split (const std::string &text, char sep);
   static std::string inline &ltrim (std::string &s)

--- a/src/multiclass.cpp
+++ b/src/multiclass.cpp
@@ -2902,12 +2902,12 @@ MNM_Origin_Multiclass::~MNM_Origin_Multiclass ()
   m_demand_truck.clear ();
     for (auto _ratio_it : m_adaptive_ratio_car)
     {
-      free (_ratio_it.second);
+      delete[] _ratio_it.second;
     }
   m_adaptive_ratio_car.clear ();
   for (auto _ratio_it : m_adaptive_ratio_truck)
     {
-      free (_ratio_it.second);
+      delete[] _ratio_it.second;
     }
   m_adaptive_ratio_truck.clear ();
   m_car_label_ratio.clear ();
@@ -3005,16 +3005,14 @@ MNM_Origin_Multiclass::add_dest_adaptive_ratio_multiclass (MNM_Destination_Multi
                                                            TFlt *ad_ratio_car, TFlt *ad_ratio_truck)
 {
   // split (15-mins demand) to (15 * 1-minute demand)
-  TFlt *_ratio_car
-    = (TFlt *) malloc (sizeof (TFlt) * m_max_assign_interval * 15);
+  TFlt *_ratio_car = new double[m_max_assign_interval * 15]();
   for (int i = 0; i < m_max_assign_interval * 15; ++i)
     {
       _ratio_car[i] = TFlt (ad_ratio_car[i]);
     }
   m_adaptive_ratio_car.insert ({ dest, _ratio_car });
 
-  TFlt *_ratio_truck
-    = (TFlt *) malloc (sizeof (TFlt) * m_max_assign_interval * 15);
+  TFlt *_ratio_truck = new double[m_max_assign_interval * 15]();
   for (int i = 0; i < m_max_assign_interval * 15; ++i)
     {
       _ratio_truck[i] = TFlt (ad_ratio_truck[i]);
@@ -3943,10 +3941,8 @@ MNM_IO_Multiclass::build_td_adaptive_ratio (const std::string &file_folder,
   if (_ratio_file.is_open ())
     {
       // printf("Start build demand profile.\n");
-      TFlt *_ratio_vector_car
-        = (TFlt *) malloc (sizeof (TFlt) * _max_interval * _num_of_minute);
-      TFlt *_ratio_vector_truck
-        = (TFlt *) malloc (sizeof (TFlt) * _max_interval * _num_of_minute);
+      TFlt *_ratio_vector_car = new double[_max_interval * _num_of_minute]();
+      TFlt *_ratio_vector_truck = new double[_max_interval * _num_of_minute]();
       TFlt _ratio_car;
       TFlt _ratio_truck;
 
@@ -3985,13 +3981,13 @@ MNM_IO_Multiclass::build_td_adaptive_ratio (const std::string &file_folder,
             }
           else
             {
-              free (_ratio_vector_car);
-              free (_ratio_vector_truck);
+              delete[] _ratio_vector_car;
+              delete[] _ratio_vector_truck;
               throw std::runtime_error ("failed to build time-dependent adaptive ratio multiclass");
             }
         }
-      free (_ratio_vector_car);
-      free (_ratio_vector_truck);
+      delete[] _ratio_vector_car;
+      delete[] _ratio_vector_truck;
       _ratio_file.close ();
     }
   else {

--- a/src/multiclass.h
+++ b/src/multiclass.h
@@ -419,9 +419,13 @@ public:
   // use this one instead of add_dest_demand in the base class
   int add_dest_demand_multiclass (MNM_Destination_Multiclass *dest,
                                   TFlt *demand_car, TFlt *demand_truck);
+  int add_dest_adaptive_ratio_multiclass (MNM_Destination_Multiclass *dest,
+                                          TFlt *ad_ratio_car, TFlt *ad_ratio_truck);
   // two new unordered_map for both classes
   std::unordered_map<MNM_Destination_Multiclass *, TFlt *> m_demand_car;
   std::unordered_map<MNM_Destination_Multiclass *, TFlt *> m_demand_truck;
+  std::unordered_map<MNM_Destination_Multiclass *, TFlt *> m_adaptive_ratio_car;
+  std::unordered_map<MNM_Destination_Multiclass *, TFlt *> m_adaptive_ratio_truck;
 
   std::vector<TFlt> m_car_label_ratio;
   std::vector<TFlt> m_truck_label_ratio;
@@ -493,7 +497,7 @@ public:
                                    TFlt flow_scalar, TFlt veh_convert_factor);
 };
 
-struct td_link_attribute_row
+struct td_link_attribute_row_biclass
 {
   std::string link_type;
   TFlt length;
@@ -524,7 +528,7 @@ public:
   virtual int update_link_attribute (TInt interval,
                                      bool verbose = false) override;
 
-  std::unordered_map<int, std::unordered_map<int, td_link_attribute_row *> *>
+  std::unordered_map<int, std::unordered_map<int, td_link_attribute_row_biclass *> *>
     *m_td_link_attribute_table;
 };
 
@@ -584,6 +588,11 @@ public:
                                       MNM_Link_Factory *link_factory,
                                       const std::string &file_name
                                       = "MNM_input_link_td_attribute");
+  
+  static int build_td_adaptive_ratio (const std::string &file_folder,
+                                      MNM_ConfReader *conf_reader,
+                                      MNM_OD_Factory *od_factory,
+                                      const std::string &file_name = "MNM_input_od_td_adaptive_ratio");
 };
 
 ///

--- a/src/multimodal.cpp
+++ b/src/multimodal.cpp
@@ -2674,6 +2674,10 @@ MNM_Origin_Multimodal::release_one_interval (TInt current_interval,
   for (auto _demand_it = m_demand_car.begin ();
        _demand_it != m_demand_car.end (); _demand_it++)
     {
+      // override adaptive ratio with time-dependent and OD-dependent one in input file
+      if (m_adaptive_ratio_car.find(_demand_it->first) != m_adaptive_ratio_car.end()) {
+        adaptive_ratio = m_adaptive_ratio_car.find(_demand_it->first) -> second[assign_interval];
+      }
       _veh_to_release = TInt (MNM_Ults::round (
         (_demand_it->second)[assign_interval] * m_flow_scalar));
       // _veh_to_release = TInt(floor((_demand_it -> second)[assign_interval] *
@@ -2722,6 +2726,10 @@ MNM_Origin_Multimodal::release_one_interval (TInt current_interval,
   for (auto _demand_it = m_demand_truck.begin ();
        _demand_it != m_demand_truck.end (); _demand_it++)
     {
+      // override adaptive ratio with time-dependent and OD-dependent one in input file
+      if (m_adaptive_ratio_truck.find(_demand_it->first) != m_adaptive_ratio_truck.end()) {
+        adaptive_ratio = m_adaptive_ratio_truck.find(_demand_it->first) -> second[assign_interval];
+      }
       _veh_to_release = TInt (MNM_Ults::round (
         (_demand_it->second)[assign_interval] * m_flow_scalar));
       // _veh_to_release = TInt(floor((_demand_it -> second)[assign_interval] *
@@ -2873,6 +2881,10 @@ MNM_Origin_Multimodal::release_one_interval_biclass (
   for (auto _demand_it = m_demand_car.begin ();
        _demand_it != m_demand_car.end (); _demand_it++)
     {
+      // override adaptive ratio with time-dependent and OD-dependent one in input file
+      if (m_adaptive_ratio_car.find(_demand_it->first) != m_adaptive_ratio_car.end()) {
+        adaptive_ratio_car = m_adaptive_ratio_car.find(_demand_it->first) -> second[assign_interval];
+      }
       _veh_to_release = TInt (MNM_Ults::round (
         (_demand_it->second)[assign_interval] * m_flow_scalar));
       // _veh_to_release = TInt(floor((_demand_it -> second)[assign_interval] *
@@ -2921,6 +2933,10 @@ MNM_Origin_Multimodal::release_one_interval_biclass (
   for (auto _demand_it = m_demand_truck.begin ();
        _demand_it != m_demand_truck.end (); _demand_it++)
     {
+      // override adaptive ratio with time-dependent and OD-dependent one in input file
+      if (m_adaptive_ratio_truck.find(_demand_it->first) != m_adaptive_ratio_truck.end()) {
+        adaptive_ratio_truck = m_adaptive_ratio_truck.find(_demand_it->first) -> second[assign_interval];
+      }
       _veh_to_release = TInt (MNM_Ults::round (
         (_demand_it->second)[assign_interval] * m_flow_scalar));
       // _veh_to_release = TInt(floor((_demand_it -> second)[assign_interval] *
@@ -9735,11 +9751,14 @@ MNM_Dta_Multimodal::build_from_files ()
                                                   m_od_factory,
                                                   "bustransit_demand");
     }
-  MNM_IO_Multimodal::read_origin_vehicle_label_ratio (m_file_folder, m_config,
-                                                      m_od_factory,
-                                                      "Origin_vehicle_label");
+  MNM_IO_Multiclass::read_origin_car_label_ratio (m_file_folder, m_config,
+                                                  m_od_factory, "MNM_origin_label_car");
+  MNM_IO_Multiclass::read_origin_truck_label_ratio (m_file_folder, m_config,
+                                                    m_od_factory, "MNM_origin_label_truck");
   MNM_IO_Multiclass::build_link_toll_multiclass (m_file_folder, m_config,
                                                  m_link_factory);
+  MNM_IO_Multiclass::build_link_td_attribute (m_file_folder, m_link_factory);
+  MNM_IO_Multiclass::build_td_adaptive_ratio(m_file_folder, m_config, m_od_factory);
   // build_workzone();
   m_workzone = nullptr;
   // record link volume and travel time in simulation

--- a/src/od.cpp
+++ b/src/od.cpp
@@ -34,7 +34,7 @@ MNM_Origin::~MNM_Origin ()
   for (auto _ratio_it = m_adaptive_ratio.begin (); _ratio_it != m_adaptive_ratio.end ();
        _ratio_it++)
     {
-      free (_ratio_it->second);
+      delete[] _ratio_it->second;
     }
   m_adaptive_ratio.clear ();
   m_vehicle_label_ratio.clear ();
@@ -55,7 +55,7 @@ MNM_Origin::add_dest_demand (MNM_Destination *dest, TFlt *demand)
 int
 MNM_Origin::add_dest_adaptive_ratio (MNM_Destination *dest, TFlt *ad_ratio)
 {
-  TFlt *_ratio = (TFlt *) malloc (sizeof (TFlt) * m_max_assign_interval);
+  TFlt *_ratio = new double[m_max_assign_interval]();
   for (int i = 0; i < m_max_assign_interval; ++i)
     {
       _ratio[i] = TFlt (ad_ratio[i]);

--- a/src/od.h
+++ b/src/od.h
@@ -39,6 +39,7 @@ public:
   };
 
   int add_dest_demand (MNM_Destination *dest, TFlt *demand);
+  int add_dest_adaptive_ratio (MNM_Destination *dest, TFlt *ad_ratio);
   MNM_DMOND *m_origin_node;
   // private:
   TInt m_frequency;
@@ -46,6 +47,7 @@ public:
   TInt m_max_assign_interval;
   TFlt m_flow_scalar;
   std::unordered_map<MNM_Destination *, TFlt *> m_demand;
+  std::unordered_map<MNM_Destination *, TFlt *> m_adaptive_ratio;
 
   std::vector<TFlt> m_vehicle_label_ratio;
 };


### PR DESCRIPTION
Enable reading one optional input file to override the global adaptive ratio with the time- and OD-dependent ratio