### PR TITLE
Fix some issues using MSVC on Windows

### DIFF
--- a/src/dlink.cpp
+++ b/src/dlink.cpp
@@ -254,7 +254,8 @@ MNM_Dlink_Ctm::update_out_veh ()
           _demand = m_cell_array[i]->get_demand ();
           _supply = m_cell_array[i + 1]->get_supply ();
           _temp_out_flux = std::min (_demand, _supply) * m_flow_scalar;
-          m_cell_array[i]->m_out_veh = MNM_Ults::round (_temp_out_flux);
+          m_cell_array[i]->m_out_veh = std::min((int)m_cell_array[i]->m_veh_queue.size(), 
+                                                MNM_Ults::round (_temp_out_flux));
         }
     }
   m_cell_array[m_num_cells - 1]->m_out_veh

--- a/src/multiclass.cpp
+++ b/src/multiclass.cpp
@@ -2939,7 +2939,7 @@ MNM_Origin_Multiclass::generate_label (TInt veh_class)
           TInt _label = 0;
           for (TFlt _p : m_car_label_ratio)
             {
-              if (_p >= _r)
+              if (!MNM_Ults::approximate_less_than(_p, _r))
                 {
                   return _label;
                 }
@@ -2966,7 +2966,7 @@ MNM_Origin_Multiclass::generate_label (TInt veh_class)
           TInt _label = 0;
           for (TFlt _p : m_truck_label_ratio)
             {
-              if (_p >= _r)
+              if (!MNM_Ults::approximate_less_than(_p, _r)) 
                 {
                   return _label;
                 }

--- a/src/multiclass.cpp
+++ b/src/multiclass.cpp
@@ -623,7 +623,8 @@ MNM_Dlink_Ctm_Multiclass::update_out_veh ()
           _temp_out_flux_car = m_cell_array[i]->m_space_fraction_car
                                * std::min (_demand_car, _supply_car);
           m_cell_array[i]->m_out_veh_car
-            = MNM_Ults::round (_temp_out_flux_car * m_flow_scalar);
+            = std::min((int)m_cell_array[i]->m_veh_queue_car.size(), 
+                       MNM_Ults::round (_temp_out_flux_car * m_flow_scalar));
 
           // truck, veh_type = TInt(1)
           _demand_truck = m_cell_array[i]->get_perceived_demand (TInt (1));
@@ -634,7 +635,8 @@ MNM_Dlink_Ctm_Multiclass::update_out_veh ()
           // condition, this makes a truck travel to next cell with a
           // probability of ffs_truck / ffs_car
           m_cell_array[i]->m_out_veh_truck
-            = MNM_Ults::round (_temp_out_flux_truck * m_flow_scalar);
+            = std::min((int)m_cell_array[i]->m_veh_queue_truck.size(), 
+                      MNM_Ults::round (_temp_out_flux_truck * m_flow_scalar));
         }
     }
   m_cell_array[m_num_cells - 1]->m_out_veh_car

--- a/src/multimodal.cpp
+++ b/src/multimodal.cpp
@@ -5602,7 +5602,7 @@ MNM_Routing_PnR_Fixed::register_veh (MNM_Veh *veh, bool track)
   for (MNM_Path *_path : _pathset->m_path_vec)
     {
       // printf("2\n");
-      if (_path->m_p >= _r)
+      if (!MNM_Ults::approximate_less_than(_path->m_p, _r)) 
         {
           _route_path = dynamic_cast<MNM_PnR_Path *> (_path);
           break;
@@ -5914,7 +5914,7 @@ MNM_Routing_PassengerBusTransit_Fixed::register_passenger (
       for (MNM_Path *_path : _pathset->m_path_vec)
         {
           // printf("2\n");
-          if (_path->m_p >= _r)
+          if (!MNM_Ults::approximate_less_than(_path->m_p, _r))
             {
               _route_path = _path;
               break;

--- a/src/od.cpp
+++ b/src/od.cpp
@@ -60,7 +60,7 @@ MNM_Origin::generate_label (TInt veh_class)
       for (TFlt _p : m_vehicle_label_ratio)
         {
           // printf("2\n");
-          if (_p >= _r)
+          if (!MNM_Ults::approximate_less_than(_p, _r))
             {
               return _label;
             }

--- a/src/routing.cpp
+++ b/src/routing.cpp
@@ -565,6 +565,7 @@ int
 MNM_Routing_Fixed::register_veh (MNM_Veh *veh, bool track)
 {
   TFlt _r = MNM_Ults::rand_flt ();
+  // std::cout << "original r: " << _r << std::endl;
   // printf("%d\n", veh -> get_origin() -> m_origin_node  -> m_node_ID);
   // printf("%d\n", veh -> get_destination() -> m_dest_node  -> m_node_ID);
   MNM_Pathset *_pathset
@@ -576,8 +577,11 @@ MNM_Routing_Fixed::register_veh (MNM_Veh *veh, bool track)
   // note m_path_vec is an ordered vector, not unordered
   for (MNM_Path *_path : _pathset->m_path_vec)
     {
-      // printf("2\n");
-      if (_path->m_p >= _r)
+      // when _r = 1, it will come to equality check of two floating numbers
+      // and simply using if (_path->m_p >= _r) can be problematic sometimes, 
+      // especially on Windows, _route_path can still be nullptr after this,
+      // which can cause vehicle on wrong link or node
+      if (!MNM_Ults::approximate_less_than(_path -> m_p, _r))
         {
           _route_path = _path;
           break;


### PR DESCRIPTION
I finally identified some issues using MSVC on Windows, if not all of them... At least after resolving them, I can run a DODE on a medium-sized network (e.g., TSMO). 

1. MNM_Routing_Fixed::register_veh does NOT properly assign a path to a vehicle due to an equality check of floating numbers.
2. CTM links may generate m_out_veh greater than the veh queue size.

