### PR TITLE
Extend path representation and generation functionality

### DIFF
--- a/src/dlink.cpp
+++ b/src/dlink.cpp
@@ -47,6 +47,18 @@ MNM_Dlink::~MNM_Dlink ()
     delete m_N_out_tree;
 }
 
+int 
+MNM_Dlink::modify_property (TInt number_of_lane, TFlt length,
+                            TFlt lane_hold_cap_car,
+                            TFlt lane_flow_cap,
+                            TFlt ffs)
+{
+  m_number_of_lane = number_of_lane;
+  m_length = length;
+  m_ffs = ffs;
+  return 0;
+}
+
 TFlt
 MNM_Dlink::get_link_freeflow_tt ()
 {

--- a/src/dlink.h
+++ b/src/dlink.h
@@ -82,6 +82,11 @@ public:
   int install_cumulative_curve ();
   int install_cumulative_curve_tree ();
 
+  virtual int modify_property (TInt number_of_lane, TFlt length,
+                               TFlt lane_hold_cap_car,
+                               TFlt lane_flow_cap,
+                               TFlt ffs);
+
   // protected:
   DLink_type m_link_type;
   TInt m_link_ID;
@@ -123,6 +128,14 @@ public:
   virtual TFlt get_link_tt () override;
   virtual TFlt get_link_tt_from_flow (TFlt flow) override;
   virtual TInt get_link_freeflow_tt_loading () override; // intervals
+  // TODO: modify_property
+  virtual int modify_property (TInt number_of_lane, TFlt length,
+                               TFlt lane_hold_cap_car,
+                               TFlt lane_flow_cap,
+                               TFlt ffs) override
+  {
+    throw std::runtime_error("MNM_Dlink_Ctm::modify_property() not implemented");
+  }
 
   // private:
   class Ctm_Cell;
@@ -175,7 +188,14 @@ public:
   virtual TFlt get_link_tt () override;
   virtual TFlt get_link_tt_from_flow (TFlt flow) override;
   virtual TInt get_link_freeflow_tt_loading () override; // intervals
-
+  // TODO: modify_property
+  virtual int modify_property (TInt number_of_lane, TFlt length,
+                               TFlt lane_hold_cap_car,
+                               TFlt lane_flow_cap,
+                               TFlt ffs) override
+  {
+    throw std::runtime_error("MNM_Dlink_Pq::modify_property() not implemented");
+  }
   // private:
   std::deque<std::pair<MNM_Veh *, TInt>> m_veh_queue;
   TInt m_volume; // vehicle number, without the flow scalar
@@ -206,6 +226,14 @@ public:
   virtual TFlt get_link_tt () override;
   virtual TFlt get_link_tt_from_flow (TFlt flow) override;
   virtual TInt get_link_freeflow_tt_loading () override; // intervals
+  // TODO: modify_property
+  virtual int modify_property (TInt number_of_lane, TFlt length,
+                               TFlt lane_hold_cap_car,
+                               TFlt lane_flow_cap,
+                               TFlt ffs) override
+  {
+    throw std::runtime_error("MNM_Dlink_Lq::modify_property() not implemented");
+  }
 
   // private:
   std::deque<MNM_Veh *> m_veh_queue;
@@ -242,6 +270,14 @@ public:
   virtual TFlt get_link_tt () override;
   virtual TFlt get_link_tt_from_flow (TFlt flow) override;
   virtual TInt get_link_freeflow_tt_loading () override; // intervals
+  // TODO: modify_property
+  virtual int modify_property (TInt number_of_lane, TFlt length,
+                               TFlt lane_hold_cap_car,
+                               TFlt lane_flow_cap,
+                               TFlt ffs) override
+  {
+    throw std::runtime_error("MNM_Dlink_Ltm::modify_property() not implemented");
+  }
 
   // private:
   std::deque<MNM_Veh *> m_veh_queue;

--- a/src/dta.cpp
+++ b/src/dta.cpp
@@ -334,6 +334,7 @@ MNM_Dta::build_from_files ()
                                            m_od_factory);
   MNM_IO::build_link_toll (m_file_folder, m_config, m_link_factory);
   MNM_IO::build_link_td_attribute(m_file_folder, m_link_factory);
+  MNM_IO::build_node_td_cost(m_file_folder, m_link_factory);
   MNM_IO::build_td_adaptive_ratio(m_file_folder, m_config, m_od_factory);
   build_workzone ();
   set_statistics ();

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -131,6 +131,8 @@ MNM_Link_Factory::MNM_Link_Factory ()
   m_link_map = std::unordered_map<TInt, MNM_Dlink *> ();
   m_td_link_attribute_table = new std::unordered_map<
     int, std::unordered_map<int, td_link_attribute_row *> *> ();
+  m_td_node_cost_table = new std::unordered_map<
+    int, std::unordered_map<int, std::unordered_map<int, float> *> *>();
 }
 
 MNM_Link_Factory::~MNM_Link_Factory ()
@@ -144,6 +146,21 @@ MNM_Link_Factory::~MNM_Link_Factory ()
       _it.second->clear ();
     }
   m_td_link_attribute_table->clear ();
+  delete m_td_link_attribute_table;
+
+  // Clear m_td_node_cost_table
+  for (auto _it : *m_td_node_cost_table)
+  {
+    for (auto _it_it : *(_it.second))
+    {
+      _it_it.second -> clear();
+      delete _it_it.second;
+    }
+    _it.second->clear();
+    delete _it.second;
+  }
+  m_td_node_cost_table->clear();
+  delete m_td_node_cost_table;
   
   for (auto _map_it = m_link_map.begin (); _map_it != m_link_map.end ();
        _map_it++)
@@ -212,6 +229,28 @@ MNM_Link_Factory::delete_link (TInt ID)
   m_link_map.erase (_map_it);
   return 0;
 }
+
+int
+MNM_Link_Factory::update_link_attribute(TInt interval, bool verbose)
+{
+    if (m_td_link_attribute_table->find (interval)
+      != m_td_link_attribute_table->end ())
+    {
+      for (auto _it : *(m_td_link_attribute_table->find (interval)->second))
+        {
+          auto _link = m_link_map.find (_it.first)->second;
+          _link->modify_property (_it.second->Lane, _it.second->length,
+                                  _it.second->RHOJ,
+                                  _it.second->Cap,
+                                  _it.second->FFS);
+          _link->m_toll = _it.second->toll;
+          if (verbose)
+            printf ("link %d attribute updated\n", _it.first);
+        }
+    }
+    return 0; // or appropriate return value
+}
+
 /**************************************************************************
                           OD factory
 **************************************************************************/

--- a/src/factory.h
+++ b/src/factory.h
@@ -63,13 +63,14 @@ public:
                                 TFlt unit_time, TFlt flow_scalar);
   MNM_Dlink *get_link (TInt ID);
   int delete_link (TInt ID);
-  virtual int update_link_attribute (TInt interval, bool verbose = false)
-  {
-    return 0;
-  };
+  virtual int update_link_attribute (TInt interval, bool verbose = false);
   std::unordered_map<TInt, MNM_Dlink *> m_link_map;
+  // <interval, <link_ID, attribute>>
   std::unordered_map<int, std::unordered_map<int, td_link_attribute_row *> *>
     *m_td_link_attribute_table;
+  // <interval, <in_link_ID, <out_link_ID, cost>>>
+  std::unordered_map<int, std::unordered_map<int, std::unordered_map<int, float> *> *>
+    *m_td_node_cost_table;
 };
 
 class MNM_OD_Factory

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -739,7 +739,7 @@ MNM_IO::build_link_td_attribute (const std::string &file_folder,
 
   if (_file.is_open ())
     {
-      printf ("Start build time-dependent link attribute.\n");
+      std::cout << "Start build time-dependent link attribute." << std::endl;
       std::getline (_file, _line); // #link_ID toll_car toll_truck
       int i = 0;
       while (std::getline (_file, _line))
@@ -806,12 +806,90 @@ MNM_IO::build_link_td_attribute (const std::string &file_folder,
           ++i;
         }
       _file.close ();
-      printf ("Finish build time-dependent link attribute.\n");
+      std::cout << "Finish build time-dependent link attribute." << std::endl;
     }
   else
     {
-      printf ("No time-dependent link attribute.\n");
+      std::cout << "No time-dependent link attribute." << std::endl;
     }
+  return 0;
+}
+
+int 
+MNM_IO::build_node_td_cost (const std::string &file_folder,
+                            MNM_Link_Factory *link_factory,
+                            const std::string &file_name)
+{
+  /* find file */
+  std::string _file_name = file_folder + "/" + file_name;
+  std::ifstream _file;
+  _file.open (_file_name, std::ios::in);
+
+  std::string _line;
+  std::vector<std::string> _words;
+  TInt _interval, _in_link_ID, _out_link_ID;
+  TFlt _cost;
+
+  auto td_node_cost_table
+    = dynamic_cast<MNM_Link_Factory *> (link_factory)
+        ->m_td_node_cost_table;
+
+  if (_file.is_open()) {
+    std::cout << "Start build time-dependent node cost." << std::endl;
+    std::getline (_file, _line); // #link_ID toll_car toll_truck
+    int i = 0;
+    while (std::getline (_file, _line))
+      {
+        // std::getline (_file, _line);
+        // std::cout << "Processing: " << _line << "\n";
+
+        _words = split (_line, ' ');
+        if (TInt (_words.size ()) == 4)
+          {
+            _interval = TInt (std::stoi (_words[0]));
+            _in_link_ID = TInt (std::stoi (_words[1]));
+            _out_link_ID = TInt (std::stoi (_words[2]));
+            _cost = TFlt (std::stod (_words[3]));
+
+            if (td_node_cost_table->find (_interval)
+                == td_node_cost_table->end ())
+              {
+                td_node_cost_table->insert (
+                  std::make_pair (_interval,
+                                  new std::unordered_map<int, std::unordered_map<int, float>*> ()));
+              }
+            if (td_node_cost_table->find (_interval)->second->find (
+                  _in_link_ID)
+                == td_node_cost_table->find (_interval)->second->end ())
+              {
+                td_node_cost_table->find (_interval)->second->insert (
+                  std::make_pair (_in_link_ID, new std::unordered_map<int, float> ()));
+              }
+            if (td_node_cost_table->find (_interval)->second->find (
+                  _in_link_ID) -> second -> find(_out_link_ID)
+                == td_node_cost_table->find (_interval)->second->find(_in_link_ID) -> second -> end ())
+              {
+                td_node_cost_table->find (_interval)->second->find(_in_link_ID) -> second -> insert (
+                  std::make_pair (_out_link_ID, _cost));
+              }
+            else {
+              throw std::runtime_error ("at interval " + std::to_string(_interval) + " in_link " + std::to_string(_in_link_ID) + " to out_link " + std::to_string(_out_link_ID) + " already exists");
+            }
+
+          }
+        else
+          {
+            std::cout << _line << std::endl;
+            throw std::runtime_error ("failed to parse line: " + _line);
+          }
+        ++i;
+      }
+    _file.close ();
+    std::cout << "Finish build time-dependent node cost." << std::endl;
+  }
+  else {
+    std::cout << "No time-dependent node cost." << std::endl;
+  }
   return 0;
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -816,7 +816,7 @@ MNM_IO::build_link_td_attribute (const std::string &file_folder,
 }
 
 Path_Table *
-MNM_IO::load_path_table (const std::string &file_name,
+MNM_IO::load_path_table (const std::string &node_seq_file_name,
                          const macposts::Graph &graph, TInt num_path,
                          bool w_buffer, bool w_ID)
 {
@@ -835,14 +835,16 @@ MNM_IO::load_path_table (const std::string &file_name,
       return nullptr;
     }
 
-  std::ifstream _path_table_file, _buffer_file;
-  std::string _buffer_file_name;
+  std::ifstream _path_table_file, _path_table_link_seq_file, _buffer_file;
+  std::string _buffer_file_name, _link_seq_file_name;
+  _link_seq_file_name = node_seq_file_name + "_link_seq";
   if (w_buffer)
     {
-      _buffer_file_name = file_name + "_buffer";
+      _buffer_file_name = node_seq_file_name + "_buffer";
       _buffer_file.open (_buffer_file_name, std::ios::in);
     }
-  _path_table_file.open (file_name, std::ios::in);
+  _path_table_file.open (node_seq_file_name, std::ios::in);
+  _path_table_link_seq_file.open (_link_seq_file_name, std::ios::in);
   Path_Table *_path_table = new Path_Table ();
 
   /* read file */
@@ -856,7 +858,109 @@ MNM_IO::load_path_table (const std::string &file_name,
   TInt _path_ID_counter = 0;
   if (_path_table_file.is_open ())
     {
-      for (int i = 0; i < Num_Path;)
+      if (_path_table_link_seq_file.is_open()) {
+
+        for (int i = 0; i < Num_Path;)
+        {
+          std::getline (_path_table_link_seq_file, _line);
+          _line = trim (_line);
+          if (_line.empty () || _line[0] == '#')
+            {
+              continue;
+            }
+          ++i;
+          if (w_buffer)
+            {
+              while (1)
+                {
+                  std::getline (_buffer_file, _buffer_line);
+                  _buffer_line = trim (_buffer_line);
+                  if (!_line.empty () && _line[0] != '#')
+                    {
+                      break;
+                    }
+                }
+              _buffer_words = split (_buffer_line, ' ');
+            }
+          // std::cout << "Processing: " << _line << "\n";
+          _words = split (_line, ' ');
+          if (_words.size () >= 1)
+            {
+              // read link ID first since, when driving graph is a MultiGraph
+              _link_ID = TInt (std::stoi (_words.front())); 
+              const auto &l_front = graph.get_link (_link_ID);
+              auto &&sd_first = graph.get_endpoints (l_front);
+              _origin_node_ID = graph.get_id (sd_first.first);
+
+              _link_ID = TInt (std::stoi (_words.back()));
+              const auto &l_back = graph.get_link (_link_ID);
+              auto &&sd_back = graph.get_endpoints (l_back);
+              _dest_node_ID = graph.get_id (sd_back.second);
+
+              if (_path_table->find (_origin_node_ID) == _path_table->end ())
+                {
+                  _new_map = new std::unordered_map<TInt, MNM_Pathset *> ();
+                  _path_table->insert (
+                    std::pair<TInt, std::unordered_map<TInt, MNM_Pathset *>
+                                      *> (_origin_node_ID, _new_map));
+                }
+              if (_path_table->find (_origin_node_ID)
+                    ->second->find (_dest_node_ID)
+                  == _path_table->find (_origin_node_ID)->second->end ())
+                {
+                  _pathset = new MNM_Pathset ();
+                  _path_table->find (_origin_node_ID)
+                    ->second->insert (
+                      std::pair<TInt, MNM_Pathset *> (_dest_node_ID, _pathset));
+                }
+
+              _path = new MNM_Path ();
+              _path->m_path_ID = _path_ID_counter;
+              _path_ID_counter += 1;
+              for (size_t j = 0; j < _words.size (); ++j)
+                {
+                  _link_ID = TInt (
+                    std::stoi (_words[j])); // read link ID first since
+                                            // transit_graph is a MultiGraph
+                  _path->m_link_vec.push_back (_link_ID);
+                }
+              for (size_t j = 0; j < _path->m_link_vec.size (); ++j)
+                {
+                  _link_ID = _path->m_link_vec[j];
+                  const auto &l = graph.get_link (_link_ID);
+                  auto &&sd = graph.get_endpoints (l);
+                  _from_ID = graph.get_id (sd.first);
+                  _to_ID = graph.get_id (sd.second);
+                  _path->m_node_vec.push_back (_from_ID);
+                  if (j == _path->m_link_vec.size () - 1)
+                    _path->m_node_vec.push_back (_to_ID);
+                }
+              Assert (_path->m_node_vec.size () == _path->m_link_vec.size () + 1);
+              Assert (_path->m_node_vec.back () == _dest_node_ID);
+
+              if (w_buffer && (_buffer_words.size () > 0))
+                {
+                  TInt _buffer_len = TInt (_buffer_words.size ());
+                  // printf("Buffer len %d\n", _buffer_len());
+                  _path->allocate_buffer (_buffer_len);
+                  for (int j = 0; j < _buffer_len; ++j)
+                    {
+                      _path->m_buffer[j]
+                        = TFlt (std::stof (trim (_buffer_words[j])));
+                    }
+                }
+
+              _path_table->find (_origin_node_ID)
+                ->second->find (_dest_node_ID)
+                ->second->m_path_vec.push_back (_path);
+            }
+        }
+        _path_table_link_seq_file.close();
+
+      }
+      else {
+
+        for (int i = 0; i < Num_Path;)
         {
           std::getline (_path_table_file, _line);
           _line = trim (_line);
@@ -942,6 +1046,7 @@ MNM_IO::load_path_table (const std::string &file_name,
                 ->second->m_path_vec.push_back (_path);
             }
         }
+      }
       _path_table_file.close ();
       if (w_buffer)
         {
@@ -955,8 +1060,7 @@ MNM_IO::load_path_table (const std::string &file_name,
   printf ("Finish Loading Path Table for Driving!\n");
   // printf("path table %p\n", _path_table);
   // printf("path table %s\n", _path_table -> find(100283) -> second ->
-  // find(150153) -> second
-  //                           -> m_path_vec.front() -> node_vec_to_string());
+  // find(150153) -> second -> m_path_vec.front() -> node_vec_to_string());
   return _path_table;
 }
 

--- a/src/io.h
+++ b/src/io.h
@@ -100,6 +100,11 @@ public:
                                     const std::string &file_name
                                     = "MNM_input_link_td_attribute");
 
+  static int build_node_td_cost (const std::string &file_folder,
+                                    MNM_Link_Factory *link_factory,
+                                    const std::string &file_name
+                                    = "MNM_input_node_td_cost");
+
   static int build_td_adaptive_ratio (const std::string &file_folder,
                                     MNM_ConfReader *conf_reader,
                                     MNM_OD_Factory *od_factory,

--- a/src/io.h
+++ b/src/io.h
@@ -47,7 +47,7 @@ public:
                            MNM_ConfReader *conf_reader,
                            MNM_OD_Factory *od_factory,
                            const std::string &file_name = "MNM_input_demand");
-  static Path_Table *load_path_table (const std::string &file_name,
+  static Path_Table *load_path_table (const std::string &node_seq_file_name,
                                       const macposts::Graph &graph,
                                       TInt num_path, bool w_buffer = false,
                                       bool w_ID = false);

--- a/src/multiclass.cpp
+++ b/src/multiclass.cpp
@@ -3432,6 +3432,8 @@ MNM_Link_Factory_Multiclass::MNM_Link_Factory_Multiclass ()
 {
   m_td_link_attribute_table = new std::unordered_map<
     int, std::unordered_map<int, td_link_attribute_row_biclass *> *> ();
+  m_td_node_cost_table = new std::unordered_map<
+    int, std::unordered_map<int, std::unordered_map<int, float> *> *> ();
 }
 
 MNM_Link_Factory_Multiclass::~MNM_Link_Factory_Multiclass ()
@@ -3445,6 +3447,7 @@ MNM_Link_Factory_Multiclass::~MNM_Link_Factory_Multiclass ()
       _it.second->clear ();
     }
   m_td_link_attribute_table->clear ();
+  delete m_td_link_attribute_table;
 }
 
 MNM_Dlink *
@@ -4421,6 +4424,7 @@ MNM_Dta_Multiclass::build_from_files ()
   MNM_IO_Multiclass::build_link_toll_multiclass (m_file_folder, m_config,
                                                  m_link_factory);
   MNM_IO_Multiclass::build_link_td_attribute (m_file_folder, m_link_factory);
+  MNM_IO::build_node_td_cost(m_file_folder, m_link_factory);
   MNM_IO_Multiclass::build_td_adaptive_ratio(m_file_folder, m_config, m_od_factory);
   // build_workzone();
   m_workzone = nullptr;
@@ -5617,6 +5621,8 @@ build_pathset_multiclass (macposts::Graph &graph, MNM_OD_Factory *od_factory,
 
   std::unordered_map<TInt, TFlt> _free_cost_map
     = std::unordered_map<TInt, TFlt> ();
+  std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> _node_cost_map
+    = std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> ();
   std::unordered_map<TInt, TInt> _free_shortest_path_tree
     = std::unordered_map<TInt, TInt> ();
   MNM_Path *_path;
@@ -5628,12 +5634,34 @@ build_pathset_multiclass (macposts::Graph &graph, MNM_OD_Factory *od_factory,
                                vot * _link_it->second->get_link_tt ()
                                  + _link_it->second->m_toll));
     }
+  // use max node cost
+  for (auto _it : *link_factory -> m_td_node_cost_table) {
+      for (auto _it_it : *_it.second) {
+        if (_node_cost_map.find(_it_it.first) == _node_cost_map.end()) {
+          _node_cost_map.insert(std::make_pair(_it_it.first, std::unordered_map<int, TFlt>()));
+        }
+        for (auto _it_it_it: *_it_it.second) {
+          if (_node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) == _node_cost_map.find(_it_it.first) -> second.end()) {
+            _node_cost_map.find(_it_it.first) -> second.insert(std::make_pair(_it_it_it.first, _it_it_it.second));
+          }
+          else {
+            if (_node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) -> second < _it_it_it.second) {
+              _node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) -> second = _it_it_it.second;
+            }
+          }
+        }
+      }
+  }
   // printf("1111\n");
   for (auto _d_it = od_factory->m_destination_map.begin ();
        _d_it != od_factory->m_destination_map.end (); _d_it++)
     {
       _dest_node_ID = _d_it->second->m_dest_node->m_node_ID;
-      MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map,
+      // // link cost only
+      // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map,
+      //                                     _free_shortest_path_tree);
+      // link cost + node cost
+      MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map, _node_cost_map,
                                           _free_shortest_path_tree);
       for (auto _o_it = od_factory->m_origin_map.begin ();
            _o_it != od_factory->m_origin_map.end (); _o_it++)
@@ -5712,14 +5740,24 @@ build_pathset_multiclass (macposts::Graph &graph, MNM_OD_Factory *od_factory,
           _dest_node_ID = _d_it->second->m_dest_node->m_node_ID;
           if (Mid_Scale > 1)
             {
+              // // link cost
+              // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
+              //                                     _mid_cost_map,
+              //                                     _mid_shortest_path_tree);
+              // link cost + node cost
               MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
-                                                  _mid_cost_map,
+                                                  _mid_cost_map, _node_cost_map,
                                                   _mid_shortest_path_tree);
             }
           if (Heavy_Scale > 1)
             {
+              // // link cost
+              // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
+              //                                     _heavy_cost_map,
+              //                                     _heavy_shortest_path_tree);
+              // link cost + node cost
               MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
-                                                  _heavy_cost_map,
+                                                  _heavy_cost_map, _node_cost_map,
                                                   _heavy_shortest_path_tree);
             }
           for (auto _o_it = od_factory->m_origin_map.begin ();
@@ -5807,6 +5845,12 @@ build_pathset_multiclass (macposts::Graph &graph, MNM_OD_Factory *od_factory,
 
   _free_cost_map.clear ();
   _free_shortest_path_tree.clear ();
+
+  // Clear _node_cost_map
+  for (auto &_it : _node_cost_map) {
+    _it.second.clear();
+  }
+  _node_cost_map.clear();
 
   return _path_table;
 }

--- a/src/multiclass.h
+++ b/src/multiclass.h
@@ -527,7 +527,7 @@ public:
 
   virtual int update_link_attribute (TInt interval,
                                      bool verbose = false) override;
-
+  // <interval, <link_ID, attribute>>
   std::unordered_map<int, std::unordered_map<int, td_link_attribute_row_biclass *> *>
     *m_td_link_attribute_table;
 };

--- a/src/multimodal.cpp
+++ b/src/multimodal.cpp
@@ -11801,6 +11801,8 @@ MNM_Passenger_Path_Driving::info2str ()
     }
   // <driving_node_sequence>, \n included
   _s += std::string ("<") + m_path->node_vec_to_string ();
+  // TODO: <driving_link_sequence>, in case of a multigraph, \n included
+  // _s += std::string ("<") + m_path->link_vec_to_string ();
   _s.pop_back ();
   _s += std::string (">") + " ";
   // <bus_transit_link_sequence>, \n included
@@ -12304,6 +12306,8 @@ MNM_Passenger_Path_PnR::info2str ()
   _s += std::to_string (m_mid_parking_lot->m_ID) + " ";
   // <driving_node_sequence>, \n included
   _s += std::string ("<") + m_path->m_driving_path->node_vec_to_string ();
+  // TODO: <driving_link_sequence>, in case of a multigraph, \n included
+  // _s += std::string ("<") + m_path->m_driving_path->link_vec_to_string ();
   _s.pop_back ();
   _s += std::string (">") + " ";
   // <bus_or_metro_transit_link_sequence>, \n included
@@ -12446,6 +12450,8 @@ MNM_Passenger_Path_RnD::info2str ()
   _s += std::string (">") + " ";
   // <driving_node_sequence>, \n included
   _s += std::string ("<") + m_path->m_driving_path->node_vec_to_string ();
+  // TODO: <driving_link_sequence>, in case of a multigraph, \n included
+  // _s += std::string ("<") + m_path->m_driving_path->link_vec_to_string ();
   _s.pop_back ();
   _s += std::string (">\n");
   return _s;
@@ -14627,7 +14633,7 @@ save_driving_path_table (const std::string &file_folder, Path_Table *path_table,
                          const std::string &buffer_file_name, bool w_buffer)
 {
   std::string _path_table_file_name = file_folder + "/" + path_file_name;
-
+  std::string _path_table_link_seq_file_name = _path_table_file_name + "_link_seq";
   std::ofstream _path_buffer_file;
   if (w_buffer)
     {
@@ -14640,11 +14646,16 @@ save_driving_path_table (const std::string &file_folder, Path_Table *path_table,
         }
     }
 
-  std::ofstream _path_table_file;
+  std::ofstream _path_table_file, _path_table_link_seq_file;
   _path_table_file.open (_path_table_file_name, std::ofstream::out);
   if (!_path_table_file.is_open ())
     {
       throw std::runtime_error ("Error happens when open _path_table_file");
+    }
+  _path_table_link_seq_file.open (_path_table_link_seq_file_name, std::ofstream::out);
+  if (!_path_table_link_seq_file.is_open ())
+    {
+      throw std::runtime_error ("Error happens when open _path_table_link_seq_file");
     }
 
   // path
@@ -14655,6 +14666,7 @@ save_driving_path_table (const std::string &file_folder, Path_Table *path_table,
           for (auto _path : _d_it.second->m_path_vec)
             {
               _path_table_file << _path->node_vec_to_string ();
+              _path_table_link_seq_file << _path->link_vec_to_string ();
               // printf("test2\n");
               if (w_buffer)
                 {
@@ -14664,6 +14676,7 @@ save_driving_path_table (const std::string &file_folder, Path_Table *path_table,
         }
     }
   _path_table_file.close ();
+  _path_table_link_seq_file.close ();
   if (w_buffer)
     {
       _path_buffer_file.close ();
@@ -14737,7 +14750,7 @@ save_pnr_path_table (const std::string &file_folder, PnR_Path_Table *path_table,
                      const std::string &buffer_file_name, bool w_buffer)
 {
   std::string _path_table_file_name = file_folder + "/" + path_file_name;
-
+  // TODO: save driving part using link sequence in case it is a multigraph
   std::ofstream _path_buffer_file;
   if (w_buffer)
     {

--- a/src/multimodal.cpp
+++ b/src/multimodal.cpp
@@ -9219,6 +9219,7 @@ MNM_IO_Multimodal::load_pnr_path_table (const macposts::Graph &driving_graph,
                 }
 
               // driving part
+              // TODO: if driving graph is a multigraph, need to read link seq
               _driving_path = new MNM_Path ();
               for (size_t j = 4; j < _words.size (); ++j)
                 {

--- a/src/multimodal.cpp
+++ b/src/multimodal.cpp
@@ -9769,6 +9769,7 @@ MNM_Dta_Multimodal::build_from_files ()
   MNM_IO_Multiclass::build_link_toll_multiclass (m_file_folder, m_config,
                                                  m_link_factory);
   MNM_IO_Multiclass::build_link_td_attribute (m_file_folder, m_link_factory);
+  MNM_IO::build_node_td_cost(m_file_folder, m_link_factory);
   MNM_IO_Multiclass::build_td_adaptive_ratio(m_file_folder, m_config, m_od_factory);
   // build_workzone();
   m_workzone = nullptr;

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -534,6 +534,8 @@ build_pathset (macposts::Graph &graph, MNM_OD_Factory *od_factory,
 
   std::unordered_map<TInt, TFlt> _free_cost_map
     = std::unordered_map<TInt, TFlt> ();
+  std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> _node_cost_map
+    = std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> ();
   std::unordered_map<TInt, TInt> _free_shortest_path_tree
     = std::unordered_map<TInt, TInt> ();
   MNM_Path *_path;
@@ -545,12 +547,34 @@ build_pathset (macposts::Graph &graph, MNM_OD_Factory *od_factory,
                                vot * _link_it->second->get_link_tt ()
                                  + _link_it->second->m_toll));
     }
+  // use max node cost
+  for (auto _it : *link_factory -> m_td_node_cost_table) {
+      for (auto _it_it : *_it.second) {
+        if (_node_cost_map.find(_it_it.first) == _node_cost_map.end()) {
+          _node_cost_map.insert(std::make_pair(_it_it.first, std::unordered_map<int, TFlt>()));
+        }
+        for (auto _it_it_it: *_it_it.second) {
+          if (_node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) == _node_cost_map.find(_it_it.first) -> second.end()) {
+            _node_cost_map.find(_it_it.first) -> second.insert(std::make_pair(_it_it_it.first, _it_it_it.second));
+          }
+          else {
+            if (_node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) -> second < _it_it_it.second) {
+              _node_cost_map.find(_it_it.first) -> second.find(_it_it_it.first) -> second = _it_it_it.second;
+            }
+          }
+        }
+      }
+  }
   // printf("1111\n");
   for (auto _d_it = od_factory->m_destination_map.begin ();
        _d_it != od_factory->m_destination_map.end (); _d_it++)
     {
       _dest_node_ID = _d_it->second->m_dest_node->m_node_ID;
-      MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map,
+      // // link cost only
+      // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map,
+      //                                     _free_shortest_path_tree);
+      // link cost + node cost
+      MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph, _free_cost_map, _node_cost_map,
                                           _free_shortest_path_tree);
       for (auto _o_it = od_factory->m_origin_map.begin ();
            _o_it != od_factory->m_origin_map.end (); _o_it++)
@@ -618,11 +642,19 @@ build_pathset (macposts::Graph &graph, MNM_OD_Factory *od_factory,
            _d_it != od_factory->m_destination_map.end (); _d_it++)
         {
           _dest_node_ID = _d_it->second->m_dest_node->m_node_ID;
+          // // link cost
+          // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
+          //                                     _mid_cost_map,
+          //                                     _mid_shortest_path_tree);
+          // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
+          //                                     _heavy_cost_map,
+          //                                     _heavy_shortest_path_tree);
+          // link cost + node cost
           MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
-                                              _mid_cost_map,
+                                              _mid_cost_map, _node_cost_map,
                                               _mid_shortest_path_tree);
           MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, graph,
-                                              _heavy_cost_map,
+                                              _heavy_cost_map, _node_cost_map,
                                               _heavy_shortest_path_tree);
           for (auto _o_it = od_factory->m_origin_map.begin ();
                _o_it != od_factory->m_origin_map.end (); _o_it++)
@@ -696,6 +728,12 @@ build_pathset (macposts::Graph &graph, MNM_OD_Factory *od_factory,
 
   _free_cost_map.clear ();
   _free_shortest_path_tree.clear ();
+
+  // Clear _node_cost_map
+  for (auto &_it : _node_cost_map) {
+    _it.second.clear();
+  }
+  _node_cost_map.clear();
 
   return _path_table;
 }

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -705,6 +705,7 @@ save_path_table (const std::string &file_folder, Path_Table *path_table,
                  MNM_OD_Factory *od_factory, bool w_buffer, bool w_cost)
 {
   std::string _path_file_name = file_folder + "/path_table";
+  std::string _link_seq_file_name = _path_file_name + "_link_seq";
   std::ofstream _path_buffer_file;
   if (w_buffer)
     {
@@ -715,11 +716,16 @@ save_path_table (const std::string &file_folder, Path_Table *path_table,
           throw std::runtime_error ("failed to open file: " + _data_file_name);
         }
     }
-  std::ofstream _path_table_file;
+  std::ofstream _path_table_file, _path_table_link_seq_file;
   _path_table_file.open (_path_file_name, std::ofstream::out);
   if (!_path_table_file.is_open ())
     {
       throw std::runtime_error ("failed to open file: " + _path_file_name);
+    }
+  _path_table_link_seq_file.open (_link_seq_file_name, std::ofstream::out);
+  if (!_path_table_link_seq_file.is_open ())
+    {
+      throw std::runtime_error ("failed to open file: " + _link_seq_file_name);
     }
 
   std::ofstream _path_time_file;
@@ -751,6 +757,7 @@ save_path_table (const std::string &file_folder, Path_Table *path_table,
           for (auto &_path : _d_it.second->m_path_vec)
             {
               _path_table_file << _path->node_vec_to_string ();
+              _path_table_link_seq_file << _path -> link_vec_to_string ();
               // printf("test2\n");
               if (w_buffer)
                 {
@@ -766,6 +773,7 @@ save_path_table (const std::string &file_folder, Path_Table *path_table,
         }
     }
   _path_table_file.close ();
+  _path_table_link_seq_file.close ();
   if (w_buffer)
     {
       _path_buffer_file.close ();
@@ -812,7 +820,8 @@ print_path_table (Path_Table *path_table, MNM_OD_Factory *od_factory,
         {
           for (auto &_path : _d_it.second->m_path_vec)
             {
-              std::cout << "path: " << _path->node_vec_to_string ();
+              std::cout << "path (node seq): " << _path->node_vec_to_string ();
+              std::cout << "path (link seq): " << _path->link_vec_to_string ();
               // printf("test2\n");
               if (w_buffer)
                 {

--- a/src/routing.cpp
+++ b/src/routing.cpp
@@ -128,6 +128,7 @@ MNM_Routing_Adaptive::MNM_Routing_Adaptive (const std::string &file_folder,
 
   m_table = new Routing_Table ();
   m_link_cost = std::unordered_map<TInt, TFlt> ();
+  m_node_cost = std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> ();
 }
 
 MNM_Routing_Adaptive::~MNM_Routing_Adaptive ()
@@ -144,6 +145,10 @@ MNM_Routing_Adaptive::~MNM_Routing_Adaptive ()
   m_table->clear ();
   delete m_table;
   m_link_cost.clear ();
+  for (auto &_it : m_node_cost) {
+    _it.second.clear();
+  }
+  m_node_cost.clear();
   delete m_self_config;
 }
 
@@ -195,6 +200,33 @@ MNM_Routing_Adaptive::update_link_cost ()
 }
 
 int
+MNM_Routing_Adaptive::update_node_cost (int interval)
+{
+  if (m_link_factory -> m_td_node_cost_table -> find(interval) != m_link_factory -> m_td_node_cost_table ->end()) {
+    for (auto &_it : m_node_cost) {
+      _it.second.clear();
+    }
+    m_node_cost.clear();
+    for (auto _it : *m_link_factory -> m_td_node_cost_table -> at(interval)) {
+      if (m_node_cost.find(_it.first) == m_node_cost.end()) {
+        m_node_cost.insert(std::make_pair(_it.first, std::unordered_map<int, TFlt>()));
+      }
+      for (auto _it_it: *_it.second) {
+        if (m_node_cost.find(_it.first) -> second.find(_it_it.first) == m_node_cost.find(_it.first) -> second.end()) {
+          m_node_cost.find(_it.first) -> second.insert(std::make_pair(_it_it.first, _it_it.second));
+        }
+        else {
+          throw std::runtime_error("Error: Node cost already exists for in link " + std::to_string(_it.first) + " and out link " + std::to_string(_it_it.first));
+        }
+      }
+      
+    }
+
+  }
+  return 0;
+}
+
+int
 MNM_Routing_Adaptive::update_routing (TInt timestamp)
 {
   // relying on m_statistics -> m_record_interval_tt, which is obtained in
@@ -207,6 +239,7 @@ MNM_Routing_Adaptive::update_routing (TInt timestamp)
     {
       // printf("Calculating the shortest path trees!\n");
       update_link_cost ();
+      update_node_cost (timestamp);
       for (auto _it = m_od_factory->m_destination_map.begin ();
            _it != m_od_factory->m_destination_map.end (); _it++)
         {
@@ -216,8 +249,14 @@ MNM_Routing_Adaptive::update_routing (TInt timestamp)
           _dest_node_ID = _dest->m_dest_node->m_node_ID;
           // printf("Destination ID: %d\n", (int) _dest_node_ID);
           _shortest_path_tree = m_table->find (_dest)->second;
+          // // link cost only
+          // MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, m_graph,
+          //                                     m_link_cost,
+          //                                     *_shortest_path_tree);
+          // link cost + node cost
           MNM_Shortest_Path::all_to_one_FIFO (_dest_node_ID, m_graph,
                                               m_link_cost,
+                                              m_node_cost,
                                               *_shortest_path_tree);
           // MNM_Shortest_Path::all_to_one_FIFO(_dest_node_ID, m_graph,
           // m_statistics -> m_record_interval_tt, *_shortest_path_tree);

--- a/src/routing.h
+++ b/src/routing.h
@@ -51,10 +51,12 @@ public:
   virtual ~MNM_Routing_Adaptive () override;
   virtual int init_routing (Path_Table *path_table = nullptr) override;
   virtual int update_link_cost ();
+  virtual int update_node_cost (int interval);
   virtual int update_routing (TInt timestamp) override;
   // private:
   MNM_Statistics *m_statistics;
   std::unordered_map<TInt, TFlt> m_link_cost;
+  std::unordered_map<TInt, std::unordered_map<TInt, TFlt>> m_node_cost;
   Routing_Table *m_table;
   TInt m_routing_freq;
   TFlt m_vot;


### PR DESCRIPTION
1. An optional link sequence file "path_table_link_seq" can be used to input the path table in case the graph is a MultiDiGraph
2. An optional time-dependent node cost "MNM_input_node_td_cost" can be provided to be used in adaptive routing and shortest path generation. A common use case is to model turn prohibitions by setting relatively large cost values.