### PR TITLE
Seed the EV node-loading shuffle (reproducibility)

### DIFF
--- a/src/ev_traffic.cpp
+++ b/src/ev_traffic.cpp
@@ -565,9 +565,12 @@ MNM_Charging_Station::evolve (TInt timestamp)
       _in_link_ind_array.push_back (i);
     }
 
-  // shuffle the in links, reserve the FIFO
-  std::random_device rng; // random sequence
-  std::shuffle (_in_link_ind_array.begin (), _in_link_ind_array.end (), rng);
+  // shuffle the in links, reserve the FIFO. The previous std::random_device
+  // ignored set_random_state entirely; pass the seeded std::rand explicitly so the
+  // shuffle honors the seed on every platform. (The 2-argument std::random_shuffle
+  // uses an implementation-defined RNG that ignores set_random_state on libc++.)
+  std::random_shuffle (_in_link_ind_array.begin (), _in_link_ind_array.end (),
+                       [] (std::ptrdiff_t n) { return std::rand () % n; });
 
   // move all in_link vehicles to queue, assuming unlimited waiting space
   for (size_t i : _in_link_ind_array)


### PR DESCRIPTION
## Summary

The electric-vehicle node model shuffled the in-link processing order with
`std::random_device`, a non-deterministic hardware RNG that ignores
`macposts.set_random_state(seed)`. Any simulation that exercises this node model was
therefore non-reproducible regardless of the seed.

## Change

`src/ev_traffic.cpp`: pass the seeded `std::rand` explicitly (3-argument
`std::random_shuffle`) so the shuffle honors `set_random_state` on every platform.

## Testing

Builds cleanly (CMake + Apple Clang, C++11, macOS arm64) and the package imports.

## Note

The 2-argument `std::random_shuffle(first, last)` used by the other node models has a
related but distinct problem: its implementation-defined RNG also ignores
`set_random_state` on libc++ (macOS), the likely cause of the Darwin reproducibility
failures tracked in #28. That is addressed in a separate PR.
