### PR TITLE
Fix DTA/Mc-DTA reproducibility on macOS (GH-28)

### DIFF
--- a/src/dnode.cpp
+++ b/src/dnode.cpp
@@ -396,9 +396,12 @@ MNM_Dnode_Inout::move_vehicle (TInt timestamp)
     {
       _out_link = m_out_link_array[j];
 
-      // shuffle the in links, reserve the FIFO
+      // shuffle the in links, reserve the FIFO. Pass the seeded std::rand
+      // explicitly; the 2-argument std::random_shuffle uses an implementation-
+      // defined RNG that on libc++ (macOS) ignores set_random_state (GH-28).
       std::random_shuffle (_in_link_ind_array.begin (),
-                           _in_link_ind_array.end ());
+                           _in_link_ind_array.end (),
+                           [] (std::ptrdiff_t n) { return std::rand () % n; });
       for (size_t i : _in_link_ind_array)
         {
           _in_link = m_in_link_array[i];

--- a/src/multiclass.cpp
+++ b/src/multiclass.cpp
@@ -2572,9 +2572,12 @@ MNM_Dnode_Inout_Multiclass::move_vehicle (TInt timestamp)
     {
       _out_link = m_out_link_array[j];
 
-      // shuffle the in links, reserve the FIFO
+      // shuffle the in links, reserve the FIFO. Pass the seeded std::rand
+      // explicitly; the 2-argument std::random_shuffle uses an implementation-
+      // defined RNG that on libc++ (macOS) ignores set_random_state (GH-28).
       std::random_shuffle (_in_link_ind_array.begin (),
-                           _in_link_ind_array.end ());
+                           _in_link_ind_array.end (),
+                           [] (std::ptrdiff_t n) { return std::rand () % n; });
       for (size_t i : _in_link_ind_array)
         {
           _in_link = m_in_link_array[i];
@@ -3174,8 +3177,11 @@ MNM_Origin_Multiclass::release_one_interval (TInt current_interval,
           m_origin_node->m_in_veh_queue.push_back (_veh);
         }
     }
+  // Pass the seeded std::rand explicitly so the shuffle honors set_random_state on
+  // every platform (the 2-argument form ignores it on libc++/macOS, GH-28).
   std::random_shuffle (m_origin_node->m_in_veh_queue.begin (),
-                       m_origin_node->m_in_veh_queue.end ());
+                       m_origin_node->m_in_veh_queue.end (),
+                       [] (std::ptrdiff_t n) { return std::rand () % n; });
   return 0;
 }
 
@@ -3289,8 +3295,11 @@ MNM_Origin_Multiclass::release_one_interval_biclass (
           m_origin_node->m_in_veh_queue.push_back (_veh);
         }
     }
+  // Pass the seeded std::rand explicitly so the shuffle honors set_random_state on
+  // every platform (the 2-argument form ignores it on libc++/macOS, GH-28).
   std::random_shuffle (m_origin_node->m_in_veh_queue.begin (),
-                       m_origin_node->m_in_veh_queue.end ());
+                       m_origin_node->m_in_veh_queue.end (),
+                       [] (std::ptrdiff_t n) { return std::rand () % n; });
   return 0;
 }
 

--- a/src/od.cpp
+++ b/src/od.cpp
@@ -178,8 +178,12 @@ MNM_Origin::release_one_interval (TInt current_interval,
           m_origin_node->m_in_veh_queue.push_back (_veh);
         }
     }
+  // Pass the seeded std::rand explicitly: the 2-argument std::random_shuffle uses
+  // an implementation-defined RNG that, on libc++ (macOS), is not the std::rand
+  // reset by set_random_state, breaking reproducibility on Darwin (GH-28).
   std::random_shuffle (m_origin_node->m_in_veh_queue.begin (),
-                       m_origin_node->m_in_veh_queue.end ());
+                       m_origin_node->m_in_veh_queue.end (),
+                       [] (std::ptrdiff_t n) { return std::rand () % n; });
   return 0;
 }
 

--- a/tests/test_dta.py
+++ b/tests/test_dta.py
@@ -1,14 +1,9 @@
 import macposts
 import numpy as np
-import platform
 import pytest
 from .conftest import SEED, NUM_REPRO_RUNS
 
 
-@pytest.mark.xfail(
-    platform.system() == "Darwin",
-    reason="failed for unknown reasons on Darwin platform (GH-28)",
-)
 @pytest.mark.parametrize("network", ["network_3link", "network_7link"])
 def test_reproducibility(network, request):
     in_ccs, out_ccs = None, None

--- a/tests/test_mcdta.py
+++ b/tests/test_mcdta.py
@@ -1,14 +1,9 @@
 import macposts
 import numpy as np
-import platform
 import pytest
 from .conftest import SEED, NUM_REPRO_RUNS
 
 
-@pytest.mark.xfail(
-    platform.system() == "Darwin",
-    reason="failed for unknown reasons on Darwin platform (GH-28)",
-)
 @pytest.mark.parametrize("network", ["network_3link_mc", "network_7link_mc"])
 def test_reproducibility(network, request):
     car_in_ccs, car_out_ccs = None, None


### PR DESCRIPTION
Fixes #28.

## Summary

Under a fixed `set_random_state(seed)`, the DTA and Mc-DTA produced different results
(and even different simulation lengths) across runs **on macOS**. This makes them
reproducible on Darwin and removes the corresponding `xfail` marks.

## Root cause

The dynamic-network-loading code shuffles the origin vehicle queues and the junction
in-link processing order with the **2-argument** `std::random_shuffle(first, last)`,
whose randomness source is *implementation-defined*:

- on **libstdc++ (Linux)** it uses `std::rand`, which `set_random_state` reseeds via
  `srand`, so runs are reproducible;
- on **libc++ (macOS)** it does **not** use that `std::rand`, so `set_random_state`
  has no effect and every run shuffles differently.

That is why the reproducibility tests failed only on Darwin "for unknown reasons".

## Fix

Pass the seeded `std::rand` explicitly through the **3-argument**
`std::random_shuffle(first, last, rng)` at each call in the single-class and
multiclass loading (`od.cpp`, `dnode.cpp`, `multiclass.cpp`), so the shuffles honor
`set_random_state` on every standard library. The `#28` `xfail` marks in
`test_dta.py` / `test_mcdta.py` are removed since those tests now pass.

## Verification (macOS arm64, Apple Clang, C++11)

- A standalone 7-link DTA harness that builds a fresh `Dta` each run (so heap layout
  differs) previously produced different cumulative counts **and different simulation
  lengths** across runs at a fixed seed; with the fix it is **bit-identical across 12
  runs**.
- The full test suite goes from `8 passed, 3 xfail, 1 xpass` to **`12 passed`** (the
  four `test_reproducibility` cases, 3-link / 7-link x single / multiclass, now pass).

## Notes

- `std::random_shuffle` is deprecated in C++14 / removed in C++17; this PR keeps it
  (the project builds at C++11) and only makes the RNG explicit. A future change could
  migrate to `std::shuffle` with one seeded generator.
- A few `std::random_shuffle` calls in other modes (`multimodal.cpp`,
  `delivery_traffic.cpp`, and the remaining ones in `ev_traffic.cpp`) share the same
  latent issue. I scoped this PR to the single-class and multiclass DTA paths that the
  failing tests exercise; happy to extend it to the other modes if you'd like. (The
  `ev_traffic.cpp` `std::random_device` instance is handled in #82.)
